### PR TITLE
Design Generic function for the getJP2Image endpoint  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
+Pipfile
 #Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow

--- a/hvpy/api.py
+++ b/hvpy/api.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 class InputParameters(BaseModel):
     date: datetime
     sourceId: int
-    jpip: Optional[bool] = Field(False, alias="jpip")
+    jpip: Optional[bool] = False
     Json: Optional[bool] = Field(False, alias="json")
 
 
@@ -71,10 +71,6 @@ if __name__ == "__main__":
     URL = "https://api.helioviewer.org/v2/getJP2Image/"
     DATE = datetime(2022, 1, 1, 23, 59, 59)
 
-    input_parameters = {"date": DATE, "sourceId": 14}
+    input_parameters = {"date": DATE, "sourceId": 14, "jpip": True}
 
-    r = execute_api_call(url=URL, input_parameters=input_parameters, output_parameters="binary")
-
-    # Save the image to a file
-    with open("test.jp2", "wb") as f:
-        f.write(r)
+    r = execute_api_call(url=URL, input_parameters=input_parameters, output_parameters="url")

--- a/hvpy/api.py
+++ b/hvpy/api.py
@@ -1,13 +1,95 @@
 __all__ = ["fake_api_call"]
 
+from datetime import datetime
+from typing import Optional
+import requests
+from pydantic import BaseModel
 
-def fake_api_call():
+
+Json = "json"
+
+
+class InputParameters(BaseModel):
+    date: datetime
+    sourceId: int
+    jpip: Optional[bool] = False
+    Json: Optional[bool] = False
+
+
+def binary(response: requests.Response):
+    return response.content
+
+
+def url(response: requests.Response):
+    return response.url
+
+
+def json(response: requests.Response):
+    return response.json()
+
+
+def parse_response(response, output_parameters: str):
     """
     _summary_
+
+    Parameters
+    ----------
+    response: ?
+        _description_
+    output_parameters: ?
+        _description_
 
     Returns
     -------
     _type_
         _description_
     """
-    return {}
+    switch = {
+        "binary": binary(response),
+        "json": json(response),
+        "url": url(response),
+    }
+    return switch.get(output_parameters, response)()
+
+
+def execute_api_call(url: str, input_parameters: dict, output_parameters):
+    """
+    _summary_
+
+    Parameters
+    ----------
+    url: str
+        _description_
+    input_parameters: dict
+        _description_
+    output_parameters: ?
+        _description_
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
+    params = InputParameters(**input_parameters)
+    response = requests.get(url, params=params)
+    print(response.url)
+    # check if we have a valid response
+    if response.status_code != 200:
+        raise Exception(f"API call failed with status code {response.status_code}")
+
+    # return parse_response(response, output_parameters)
+
+
+if __name__ == "__main__":
+
+    URL = "https://api.helioviewer.org/v2/getJP2Image/"
+    DATE = datetime(2003, 10, 6, 0, 0, 0, 0).isoformat() + "Z"
+    SOURCE_ID = "14"
+    data = {"date": DATE, "sourceId": SOURCE_ID}
+
+    r = requests.get(url, params=data)
+    print(r.url)
+    # input_parameters = {"date": datetime(2014, 1, 1, 0, 0, 0).isoformat() + "Z", "sourceId": 14}
+
+    # r = execute_api_call(url=URL, input_parameters=input_parameters, output_parameters="url")
+    # print(r)


### PR DESCRIPTION
Remove `fake_api_call()` function will fail CI/CD tests.