### PR TITLE
Reduce example output for getstatus's doctest

### DIFF
--- a/hvpy/facade.py
+++ b/hvpy/facade.py
@@ -166,8 +166,8 @@ def getStatus() -> Union[bytes, str, Dict[str, Any]]:
     Examples
     --------
     >>> from hvpy import getStatus
-    >>> getStatus()
-    {'AIA': ..., 'COSMO': ..., 'HMI': ..., 'LASCO': ..., 'SECCHI': ..., 'SWAP': ..., 'XRT': ...}
+    >>> getStatus() # doctest: +SKIP
+    {'AIA': ..., ... 'COSMO': ..., 'HMI': ..., 'LASCO': ..., 'SECCHI': ..., 'SWAP': ..., 'XRT': ...}
     """
     params = getStatusInputParameters()
     return execute_api_call(input_parameters=params)

--- a/hvpy/facade.py
+++ b/hvpy/facade.py
@@ -166,8 +166,8 @@ def getStatus() -> Union[bytes, str, Dict[str, Any]]:
     Examples
     --------
     >>> from hvpy import getStatus
-    >>> getStatus() # doctest: +SKIP
-    {'AIA': ..., ... 'COSMO': ..., 'HMI': ..., 'LASCO': ..., 'SECCHI': ..., 'SWAP': ..., 'XRT': ...}
+    >>> getStatus()
+    {'AIA': ..., ...}
     """
     params = getStatusInputParameters()
     return execute_api_call(input_parameters=params)


### PR DESCRIPTION
It breaks whenever the ordering of keys in the JSON object changes.