### PR TITLE
Pin pydantic to < 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     requests>=2.27.0
-    pydantic>=1.9.1
+    pydantic>=1.9.1,<2
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
Pydantic version 2 was just released, which seems to throw errors when used with `hvpy` - see this `sunpy` test log for an example: https://github.com/sunpy/sunpy/actions/runs/5429745708/jobs/9874982895#step:10:5372

I've pinned the version of pydantic to < 2 as an easy fix for now.