### PR TITLE
Separate doc build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,22 @@ jobs:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
+      envs: |
+        - linux: py38
+        - macos: py310
+        - windows: py39
+  docs:
+    needs: [test]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      submodules: false
+      coverage: codecov
+      toxdeps: tox-pypi-filter
       libraries: |
         apt:
           - libopenjp2-7
           - graphviz
       envs: |
-        - linux: py38
-        - macos: py310
-        - windows: py39
         - linux: build_docs
   publish:
     # Build wheels when pushing to any branch except main
@@ -61,7 +69,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       test_extras: 'all,tests'
-      test_command: 'HELIOVIEWER_API_URL=https://api.beta.helioviewer.org/v2/ pytest -p no:warnings --doctest-rst -m "not mpl_image_compare" --pyargs hvpy'
+      test_command: 'HELIOVIEWER_API_URL=https://api.beta.helioviewer.org/v2/ pytest -p no:warnings --doctest-rst --pyargs hvpy'
       submodules: false
     secrets:
       pypi_token: ${{ secrets.pypi_token }}


### PR DESCRIPTION
Does mean, we now allow the docs to fail for the time being when we do a release.